### PR TITLE
Corrections to vagrant workflow and dockerfile support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+docker-build.sh
+docker-run.sh
+docker-stop.sh
+docker-save-image.sh
+dockerfile
+.dynamic/
+.vagrant/
+docker.md
+docker-images/

--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,6 @@ dockerfile
 .vagrant/
 docker.md
 docker-images/
+README.md
+Vagrantfile
+provision/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.dynamic/
+.vagrant/
+docker-images/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "apps/dynamic-private"]
+	path = apps/dynamic-private
+	url = git@github.com:duality-solutions/dynamic-private.git

--- a/README.md
+++ b/README.md
@@ -3,41 +3,67 @@ Vagrant files to setup ubuntu VM for Dynamic node build
 
 ## Setup and Build notes
 
+Pull the `dynamic-private` submodule with
+
+    git submodule update --recursive --remote
+
 Run:
+
     vagrant up
 
-Clone duality-private repo into the apps folder
-
 SSH into vagrant:
+
     vagrant ssh
 
 run:
+
     cd apps/dynamic-private
     ./autogen.sh && ./configure --without-gui --disable-tests --disable-bench && make
 
 ## Configuration
-Dynamic configuration can be found in vagrant: ~/.dynamic/dynamic.conf
+Dynamic configuration can be found in vagrant: `~/.dynamic/dynamic.conf`, if this has not been created, then
 
-Add the following to conf:
+    ./src/dynamicd --daemon
 
-testnet=1
-daemon=1
-server=1
-rpcbind=0.0.0.0
-rpcallowip=0.0.0.0/0
-addnode=159.203.17.98
-addnode=18.214.64.9
-addnode=178.128.144.29
-addnode=206.189.30.176
-addnode=178.128.180.138
-addnode=178.128.63.114
-addnode=138.197.167.18
+wait for a few seconds
+
+    ./src/dynamic-cli stop
+
+and a configuration file should now be created at `~/.dynamic/dynamic.conf`
+
+Comment out the following lines:
+
+    rpcport=33350
+    port=33300
+
+so they look like this:
+
+    #rpcport=33350
+    #port=33300
+
+
+then add the following to the end of the file:
+
+    testnet=1
+    daemon=1
+    server=1
+    rpcbind=0.0.0.0
+    rpcallowip=0.0.0.0/0
+    addnode=159.203.17.98
+    addnode=18.214.64.9
+    addnode=178.128.144.29
+    addnode=206.189.30.176
+    addnode=178.128.180.138
+    addnode=178.128.63.114
+    addnode=138.197.167.18
 
 ## Running commands
 
-Running Server - ./src/dynamicd --daemon
-Stopping Server - ./src/dynamic-cli stop
-Help - ./src/dynamic-cli help
+Running Server - `./src/dynamicd --daemon`
+
+Stopping Server - `./src/dynamic-cli stop`
+
+Help - `./src/dynamic-cli help`
 
 ## RPC Calls
 

--- a/README.md
+++ b/README.md
@@ -21,41 +21,7 @@ run:
     ./autogen.sh && ./configure --without-gui --disable-tests --disable-bench && make
 
 ## Configuration
-Dynamic configuration can be found in vagrant: `~/.dynamic/dynamic.conf`, if this has not been created, then
-
-    ./src/dynamicd --daemon
-
-wait for a few seconds
-
-    ./src/dynamic-cli stop
-
-and a configuration file should now be created at `~/.dynamic/dynamic.conf`
-
-Comment out the following lines:
-
-    rpcport=33350
-    port=33300
-
-so they look like this:
-
-    #rpcport=33350
-    #port=33300
-
-
-then add the following to the end of the file:
-
-    testnet=1
-    daemon=1
-    server=1
-    rpcbind=0.0.0.0
-    rpcallowip=0.0.0.0/0
-    addnode=159.203.17.98
-    addnode=18.214.64.9
-    addnode=178.128.144.29
-    addnode=206.189.30.176
-    addnode=178.128.180.138
-    addnode=178.128.63.114
-    addnode=138.197.167.18
+Dynamic configuration should be created at: `~/.dynamic/dynamic.conf`. Copy the config from `./docker/dynamic.default.conf` into this file.
 
 ## Running commands
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ run:
     ./autogen.sh && ./configure --without-gui --disable-tests --disable-bench && make
 
 ## Configuration
-Dynamic configuration should be created at: `~/.dynamic/dynamic.conf`. Copy the config from `./docker/dynamic.default.conf` into this file.
+You will need to create a dynamic configuration file at: `~/.dynamic/dynamic.conf` on the vagrant VM
+
+Copy the config from `./docker/dynamic.default.conf` into this file.
 
 ## Running commands
 

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+git submodule update --recursive --remote
+docker build --rm -f "dockerfile" -t dynamicd-testing:latest .

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+docker run -d --name dynamicd -v `pwd`/.dynamic:/root/.dynamic -p 33450:33450 dynamicd-testing:latest

--- a/docker-save-image.sh
+++ b/docker-save-image.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+mkdir -p ./docker-images
+docker save dynamicd-testing:latest | gzip -9 > ./docker-images/dynamicd-testing-docker-image.tar.gz

--- a/docker-stop.sh
+++ b/docker-stop.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+docker stop dynamicd
+docker rm dynamicd

--- a/docker-stop.sh
+++ b/docker-stop.sh
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
+docker exec dynamicd dynamic-cli stop
+sleep 10
 docker stop dynamicd
 docker rm dynamicd

--- a/docker.md
+++ b/docker.md
@@ -45,25 +45,7 @@ Now:
 
     ./docker-run.sh
 
-wait for about ten seconds and ensure that directory `./.dynamic` is created (this directory is mounted into to the docker image) and that `./.dynamic/dynamic.conf` looks like this (except for `rpcuser` and `rpcpassword`, which will be different for each user):
-
-    #Do not use special characters with username/password
-    rpcuser=someusername
-    rpcpassword=somepassword
-    #rpcport=33350
-    #port=33300
-    testnet=1
-    daemon=1
-    server=1
-    rpcbind=0.0.0.0
-    rpcallowip=0.0.0.0/0
-    addnode=159.203.17.98
-    addnode=18.214.64.9
-    addnode=178.128.144.29
-    addnode=206.189.30.176
-    addnode=178.128.180.138
-    addnode=178.128.63.114
-    addnode=138.197.167.18
+...wait for about ten seconds and ensure that `./.dynamic/dynamic.conf` exists and that directory `./.dynamic/testnet3` directory has been created. If yes, this is a strong indication that everything is working correctly.
 
 If everything is working correctly, the RPC endpoint will be exposed on `localhost` port `33450` and can be connected to from node using the [`bitcoin-core`](https://www.npmjs.com/package/bitcoin-core) NPM package:
 
@@ -75,6 +57,28 @@ If everything is working correctly, the RPC endpoint will be exposed on `localho
         password: "somepassword"   #use rpcpassword value from ./.dynamic/dynamic.conf
     })
     bc.command("getinfo").then(r => console.log(r))
+
+You can check "sync" status by issuing command
+
+    docker exec dynamicd dynamic-cli dnsync status
+
+When all synced, you can expect a response that looks like this:
+
+    {
+        "AssetID": 999,
+        "AssetName": "DYNODE_SYNC_FINISHED",
+        "AssetStartTime": 1544715953,
+        "Attempt": 0,
+        "IsBlockchainSynced": true,
+        "IsDynodeListSynced": true,
+        "IsWinnersListSynced": true,
+        "IsSynced": true,
+        "IsFailed": false
+    }
+
+You can view the dynamicd debug log with
+
+    docker exec dynamicd tail -f /root/.dynamic/testnet3/debug.log
 
 ## stopping the docker instance
 

--- a/docker.md
+++ b/docker.md
@@ -1,0 +1,82 @@
+# Running dynamicd daemon in docker
+
+## Prerequisites
+
+To reduce the size of the docker context to an absolute minimum, please clone a fresh copy of this repository. Things work a little differently to the vagrant process, and build artefacts from the vagrant workflow in `./apps/dynamic-private` will significantly increase the space needed to perform a docker build.
+
+You must have read access to the [`dynamic-private`](https://github.com/duality-solutions/dynamic-private) repository
+
+Docker / Docker for Mac / Docker for Windows must be installed
+
+The `~/.dynamic` folder in the container will be mapped to folder `./.dynamic` in this folder. To avoid sharing issues on MacOS, ensure that this folder is checked out somewhere in `/Users` (see https://docs.docker.com/docker-for-mac/#file-sharing for further information)
+
+## Building the docker image
+
+You may be able to skip this step and download a pre-built docker image. See below.
+
+In a bash shell, change to this directory.
+
+The docker image can be built by running the bash script:
+
+    ./docker-build.sh
+
+This will first checkout the `dynamic-private` submodule into `./apps/dynamic-private/`, then build a new docker image tagged as `dynamicd-testing:latest`. The build process can take a significant amount of time.
+
+### Saving a built image to file
+
+This step is only necessary for sharing the built image
+
+    mkdir -p ./docker-images
+    docker save dynamicd-testing:latest | gzip -9 > ./docker-images/dynamicd-testing-docker-image.tar.gz
+
+As this involves gzipping about 2GiB of data down to ~500MiB, so it might take some time
+
+### Restoring a built image from file
+
+If a pre-built image is available, it can be restored with
+
+    cat ./docker-images/dynamicd-testing-docker-image.tar.gz | gzip -d | docker load 
+
+## Running the docker image
+
+If already running in vagrant, take down the vagrant machine with `vagrant halt`, otherwise you might encounter port conflicts.
+
+Now:
+
+    ./docker-run.sh
+
+wait for about ten seconds and ensure that directory `./.dynamic` is created (this directory is mounted into to the docker image) and that `./.dynamic/dynamic.conf` looks like this (except for `rpcuser` and `rpcpassword`, which will be different for each user):
+
+    #Do not use special characters with username/password
+    rpcuser=someusername
+    rpcpassword=somepassword
+    #rpcport=33350
+    #port=33300
+    testnet=1
+    daemon=1
+    server=1
+    rpcbind=0.0.0.0
+    rpcallowip=0.0.0.0/0
+    addnode=159.203.17.98
+    addnode=18.214.64.9
+    addnode=178.128.144.29
+    addnode=206.189.30.176
+    addnode=178.128.180.138
+    addnode=178.128.63.114
+    addnode=138.197.167.18
+
+If everything is working correctly, the RPC endpoint will be exposed on `localhost` port `33450` and can be connected to from node using the [`bitcoin-core`](https://www.npmjs.com/package/bitcoin-core) NPM package:
+
+    const bitcoin = require("bitcoin-core");
+    const bc = new bitcoin({
+        host: "localhost", 
+        port: "33450", 
+        username: "someusername",  #use rpcuser value from ./.dynamic/dynamic.conf
+        password: "somepassword"   #use rpcpassword value from ./.dynamic/dynamic.conf
+    })
+    bc.command("getinfo").then(r => console.log(r))
+
+## stopping the docker instance
+
+    ./docker-stop.sh
+

--- a/docker/configure.sh
+++ b/docker/configure.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+if [ ! -f ~/.dynamic/dynamic.conf ]; then
+    dynamicd --daemon
+    sleep 5
+    dynamic-cli stop
+    echo -e 'testnet=1\ndaemon=1\nserver=1\nrpcbind=0.0.0.0\nrpcallowip=0.0.0.0/0\naddnode=159.203.17.98\naddnode=18.214.64.9\naddnode=178.128.144.29\naddnode=206.189.30.176\naddnode=178.128.180.138\naddnode=178.128.63.114\naddnode=138.197.167.18' >> ~/.dynamic/dynamic.conf
+    sed '/^\(rpc\)\?port\=/s/^/#/' -i ~/.dynamic/dynamic.conf
+fi

--- a/docker/configure.sh
+++ b/docker/configure.sh
@@ -1,8 +1,4 @@
 #!/usr/bin/env bash
 if [ ! -f ~/.dynamic/dynamic.conf ]; then
-    dynamicd --daemon
-    sleep 5
-    dynamic-cli stop
-    echo -e 'testnet=1\ndaemon=1\nserver=1\nrpcbind=0.0.0.0\nrpcallowip=0.0.0.0/0\naddnode=159.203.17.98\naddnode=18.214.64.9\naddnode=178.128.144.29\naddnode=206.189.30.176\naddnode=178.128.180.138\naddnode=178.128.63.114\naddnode=138.197.167.18' >> ~/.dynamic/dynamic.conf
-    sed '/^\(rpc\)\?port\=/s/^/#/' -i ~/.dynamic/dynamic.conf
+    cp /dynamic/dynamic.default.conf ~/.dynamic/dynamic.conf
 fi

--- a/docker/dynamic.default.conf
+++ b/docker/dynamic.default.conf
@@ -1,0 +1,17 @@
+#Do not use special characters with username/password
+rpcuser=CWIXE4bsgA
+rpcpassword=KT7xrPgVWWvakblJApSh8
+#rpcport=33350
+#port=33300
+testnet=1
+daemon=1
+server=1
+rpcbind=0.0.0.0
+rpcallowip=0.0.0.0/0
+addnode=159.203.17.98
+addnode=18.214.64.9
+addnode=178.128.144.29
+addnode=206.189.30.176
+addnode=178.128.180.138
+addnode=178.128.63.114
+addnode=138.197.167.18

--- a/dockerfile
+++ b/dockerfile
@@ -12,9 +12,7 @@ RUN ./configure --without-gui --disable-tests --disable-bench
 RUN make
 FROM ubuntu:bionic
 WORKDIR /dynamic
-COPY --from=build-env /dynamic/build/apps/dynamic-private/src/dynamicd ./dist/
-COPY --from=build-env /dynamic/build/apps/dynamic-private/src/dynamic-cli ./dist/
-COPY --from=build-env /dynamic/build/apps/dynamic-private/src/dynamic-tx ./dist/
+COPY --from=build-env /dynamic/build/apps/dynamic-private/src/dynamicd /dynamic/build/apps/dynamic-private/src/dynamic-cli /dynamic/build/apps/dynamic-private/src/dynamic-tx ./dist/
 RUN apt-get update  \
     && apt-get install -y  \
         libzmq5 \
@@ -36,5 +34,5 @@ RUN apt-get update  \
     && rm -rf /var/lib/apt/lists/*
 
 ENV PATH="/dynamic/dist:${PATH}"
-COPY ./docker/configure.sh .
+COPY ./docker/* ./
 CMD ["/bin/bash","-c","./configure.sh && dynamicd --daemon && tail -f /dev/null"]

--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,38 @@
+FROM ubuntu:bionic as build-env
+WORKDIR /dynamic
+RUN apt-get -qq update
+RUN apt-get install -y build-essential libtool autotools-dev autoconf pkg-config libssl-dev libboost-all-dev libcrypto++-dev libevent-dev libzmq3-dev software-properties-common git
+RUN apt-add-repository -y ppa:bitcoin/bitcoin
+RUN apt-get update -y 
+RUN apt-get install -y libdb4.8-dev libdb4.8++-dev
+COPY . ./build/
+WORKDIR /dynamic/build/apps/dynamic-private
+RUN ./autogen.sh 
+RUN ./configure --without-gui --disable-tests --disable-bench 
+RUN make
+FROM ubuntu:bionic
+WORKDIR /dynamic
+COPY --from=build-env /dynamic/build/apps/dynamic-private/src ./dist
+RUN apt-get update  \
+    && apt-get install -y  \
+        libzmq5 \
+        libboost-system1.65.1 \
+        libboost-filesystem1.65.1 \
+        libboost-thread1.65.1 \
+        libboost-chrono1.65.1 \
+        libboost-program-options1.65.1 \
+        libssl1.1 \
+        libcrypto++6 \
+        libevent-2.1-6 \
+        libevent-pthreads-2.1-6 \
+        software-properties-common  \
+    && apt-add-repository -y ppa:bitcoin/bitcoin  \
+    && apt-get update   \
+    && apt-get install -y libdb4.8 libdb4.8++  \
+    && apt-get remove --purge -y software-properties-common  \
+    && apt-get autoremove -y \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV PATH="/dynamic/dist:${PATH}"
+COPY ./docker/configure.sh .
+CMD ["/bin/bash","-c","./configure.sh && dynamicd --daemon && tail -f /dev/null"]

--- a/dockerfile
+++ b/dockerfile
@@ -12,7 +12,9 @@ RUN ./configure --without-gui --disable-tests --disable-bench
 RUN make
 FROM ubuntu:bionic
 WORKDIR /dynamic
-COPY --from=build-env /dynamic/build/apps/dynamic-private/src ./dist
+COPY --from=build-env /dynamic/build/apps/dynamic-private/src/dynamicd ./dist/
+COPY --from=build-env /dynamic/build/apps/dynamic-private/src/dynamic-cli ./dist/
+COPY --from=build-env /dynamic/build/apps/dynamic-private/src/dynamic-tx ./dist/
 RUN apt-get update  \
     && apt-get install -y  \
         libzmq5 \

--- a/provision/setup.sh
+++ b/provision/setup.sh
@@ -1,6 +1,6 @@
 echo "Provisioning virtual machine..."
 
 apt-get -qq update > /dev/null
-apt-get install -y build-essential libtool autotools-dev autoconf pkg-config libssl-dev libboost-all-dev libcrypto++-dev libevent-dev > /dev/null
-add-apt-repository -y ppa:bitcoin/bitcoin > /dev/null
+apt-get install -y build-essential libtool autotools-dev autoconf pkg-config libssl-dev libboost-all-dev libcrypto++-dev libevent-dev libzmq3-dev software-properties-common > /dev/null
+apt-add-repository -y ppa:bitcoin/bitcoin > /dev/null
 apt-get update -y && sudo apt-get install -y libdb4.8-dev libdb4.8++-dev > /dev/null


### PR DESCRIPTION
I've fixed the documentation for the vagrant workflow and added dynamic-private as a submodule instead of requiring a manual clone.

Have added everything required to make a docker image of the dynamicd and added docker.md with documentation