### PR TITLE
Update Dynamic submodule URL format

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "apps/dynamic"]
 	path = apps/dynamic
-	url = git@github.com:duality-solutions/Dynamic.git
+	url = https://github.com/duality-solutions/dynamic
 	branch = v2.4-WIP-BDAP


### PR DESCRIPTION
Updating the Git URL format seems to fix the issue when `/docker-build.sh` tries to clone the Dynamic repo using Ubuntu 18.04. I have not tested this update using MacOS or Windows.